### PR TITLE
Add pig counter and next scene button

### DIFF
--- a/Assets/Scripts/NextSceneButton.cs
+++ b/Assets/Scripts/NextSceneButton.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public class NextSceneButton : MonoBehaviour
+{
+    public void LoadNextScene()
+    {
+        SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex + 1);
+    }
+}

--- a/Assets/Scripts/NextSceneButton.cs.meta
+++ b/Assets/Scripts/NextSceneButton.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: c340799d-c40c-4cdb-86d9-4298d0214dfd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences:
+  - icon: {instanceID: 0}
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/PigCounter.cs
+++ b/Assets/Scripts/PigCounter.cs
@@ -1,0 +1,46 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+public class PigCounter : MonoBehaviour
+{
+    public Button nextSceneButtonPrefab;
+    public Transform uiParent;
+
+    private Button spawnedButton;
+
+    void Update()
+    {
+        if (spawnedButton != null) return;
+
+        if (CountRemainingPigs() == 0)
+        {
+            SpawnButton();
+        }
+    }
+
+    int CountRemainingPigs()
+    {
+        DestroyOnImpact[] targets = FindObjectsOfType<DestroyOnImpact>();
+        int count = 0;
+        foreach (var t in targets)
+        {
+            if (t.gameObject.name.Contains("Pig"))
+            {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    void SpawnButton()
+    {
+        if (nextSceneButtonPrefab == null) return;
+        spawnedButton = Instantiate(nextSceneButtonPrefab, uiParent);
+        NextSceneButton loader = spawnedButton.GetComponent<NextSceneButton>();
+        if (loader == null)
+        {
+            loader = spawnedButton.gameObject.AddComponent<NextSceneButton>();
+        }
+        spawnedButton.onClick.AddListener(loader.LoadNextScene);
+    }
+}

--- a/Assets/Scripts/PigCounter.cs.meta
+++ b/Assets/Scripts/PigCounter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: edcc14d0-8791-4e60-a274-e61bddd3754c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences:
+  - icon: {instanceID: 0}
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/README.md
+++ b/README.md
@@ -33,3 +33,12 @@ The project also includes a minimal setup for an Angry Birds style game using th
 6. Press Play and drag the mouse to aim. A line shows the expected path, release to launch a bird.
 
 With only Unity's primitive objects and these two scripts you can quickly prototype a simple 3D Angry Birds style experience.
+
+## PigCounter and NextSceneButton
+
+Two additional scripts support level progression:
+
+- `PigCounter.cs` counts how many pigs remain in the scene. When all objects named `Pig` are destroyed, it spawns a UI button for proceeding to the next scene.
+- `NextSceneButton.cs` handles that button's click by loading the following scene in the build settings.
+
+Attach `PigCounter` to any manager object and assign a `Button` prefab to `nextSceneButtonPrefab`.


### PR DESCRIPTION
## Summary
- add `PigCounter` manager that spawns a button when all pigs are gone
- add `NextSceneButton` to load the following scene
- document new scripts in README

## Testing
- `git status`

------
https://chatgpt.com/codex/tasks/task_e_68770e8b3fe08331ad2a57dfd8ab685c