### PR TITLE
Add fall damage support

### DIFF
--- a/Assets/Scripts/DestroyOnImpact.cs
+++ b/Assets/Scripts/DestroyOnImpact.cs
@@ -2,11 +2,30 @@ using UnityEngine;
 
 public class DestroyOnImpact : MonoBehaviour
 {
+    [Tooltip("Relative collision velocity required to destroy this object.")]
     public float impactThreshold = 10f;
+
+    [Tooltip("Downward speed on landing that also causes destruction.")]
+    public float fallSpeedThreshold = 8f;
+
+    private Rigidbody rb;
+
+    private void Awake()
+    {
+        rb = GetComponent<Rigidbody>();
+    }
 
     private void OnCollisionEnter(Collision collision)
     {
-        if (collision.relativeVelocity.magnitude > impactThreshold)
+        float impactVelocity = collision.relativeVelocity.magnitude;
+
+        float downSpeed = 0f;
+        if (rb != null)
+        {
+            downSpeed = Mathf.Abs(Vector3.Dot(rb.velocity, Vector3.down));
+        }
+
+        if (impactVelocity > impactThreshold || downSpeed > fallSpeedThreshold)
         {
             Destroy(gameObject);
         }

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ towards the mouse click position.
 The project also includes a minimal setup for an Angry Birds style game using the new scripts:
 
 - `BirdLauncher.cs` – handles dragging and launching a bird from a slingshot position.
-- `DestroyOnImpact.cs` – destroys an object when the collision impact exceeds a threshold.
+- `DestroyOnImpact.cs` – destroys an object when the collision impact or falling speed is large enough.
 
 ### Basic scene setup
 1. Create a new empty GameObject at the slingshot position and assign it as `launchPosition` on a `BirdLauncher` component.
 2. Create a sphere prefab with a `Rigidbody` and assign it as `birdPrefab` on the `BirdLauncher`.
 3. Add a `LineRenderer` component to the same object and assign it to the `directionLine` field of `BirdLauncher` to display the predicted trajectory while dragging.
 4. Build the stage using cubes, cylinders or spheres with `Rigidbody` components for blocks and pigs.
-5. Attach `DestroyOnImpact` to any object that should break on strong collision (e.g. pigs or blocks).
+5. Attach `DestroyOnImpact` to any object that should break on strong collision (e.g. pigs or blocks). It now also removes objects that hit the ground at high speed.
 6. Press Play and drag the mouse to aim. A line shows the expected path, release to launch a bird.
 
 With only Unity's primitive objects and these two scripts you can quickly prototype a simple 3D Angry Birds style experience.


### PR DESCRIPTION
## Summary
- extend `DestroyOnImpact` to also destroy objects that land with high downward speed
- mention new behaviour in README

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6877447b6e1c83318c81809dc7426a50