### PR TITLE
fix: handle null bird and tidy launcher

### DIFF
--- a/Assets/Scripts/BirdLauncher.cs
+++ b/Assets/Scripts/BirdLauncher.cs
@@ -38,20 +38,17 @@ public class BirdLauncher : MonoBehaviour
         CancelInvoke(nameof(DeactivateBlackHole));
         blackHoleActive = false;
 
-        Rigidbody prefab = null;
-        foreach (var b in birdPrefabs)
+        // Find the prefab that matches the selected bird type
+        Rigidbody prefab = birdPrefabs.Find(b =>
         {
             BirdType bt = b.GetComponent<BirdType>();
-            if (bt != null && bt.type == selectedBird)
-            {
-                prefab = b;
-                break;
-            }
-        }
+            return bt != null && bt.type == selectedBird;
+        });
 
         if (prefab == null)
         {
             Debug.LogWarning($"No prefab found for {selectedBird}");
+            currentBird = null;
             return;
         }
 
@@ -72,6 +69,16 @@ public class BirdLauncher : MonoBehaviour
             AttractObjects();
         }
 
+        if (currentBird == null)
+        {
+            return;
+        }
+
+        HandleInput();
+    }
+
+    void HandleInput()
+    {
         if (Input.GetMouseButtonDown(0))
         {
             dragStart = GetMouseWorldPos();


### PR DESCRIPTION
## Summary
- prevent null reference when selecting a bird without a prefab
- centralize input handling and early-return when no bird is available

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_6891abb45860833192f5b769bff011db