### PR TITLE
Add shotgun pellet collision handling

### DIFF
--- a/Assets/Scripts/ShotgunPellet.cs
+++ b/Assets/Scripts/ShotgunPellet.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+
+public class ShotgunPellet : MonoBehaviour
+{
+    private float spawnTime;
+
+    private void Awake()
+    {
+        spawnTime = Time.time;
+    }
+
+    private void OnCollisionEnter(Collision collision)
+    {
+        if (Time.time - spawnTime >= 0.7f)
+        {
+            return;
+        }
+
+        DestroyOnImpact target = collision.gameObject.GetComponent<DestroyOnImpact>();
+        if (target != null)
+        {
+            Destroy(collision.gameObject);
+        }
+    }
+}

--- a/Assets/Scripts/ShotgunPellet.cs.meta
+++ b/Assets/Scripts/ShotgunPellet.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 50e66ae517d844839375f449f98330ea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences:
+  - icon: {instanceID: 0}
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add ShotgunPellet component that tracks spawn time and only destroys DestroyOnImpact targets in the first 0.7 seconds

## Testing
- `dotnet test` *(fails: command not found; attempted `apt-get install -y dotnet-sdk-7.0` but package unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6891c2ff84f0833199fc763ac218cc1e