### PR TITLE
Add shotgun spawn for GunnerBird

### DIFF
--- a/Assets/Scripts/GunnerBird.cs
+++ b/Assets/Scripts/GunnerBird.cs
@@ -2,18 +2,34 @@ using UnityEngine;
 
 public class GunnerBird : MonoBehaviour
 {
+    [SerializeField] private Transform spawnPoint;
     [SerializeField] private GameObject shotgunPrefab;
 
-    private void Start()
+    private Rigidbody rb;
+    private bool launched;
+
+    private void Awake()
     {
-        Invoke(nameof(Shoot), 2f);
+        rb = GetComponent<Rigidbody>();
     }
 
-    private void Shoot()
+    private void Update()
     {
-        if (shotgunPrefab != null)
+        if (!launched && rb != null && !rb.isKinematic)
         {
-            Instantiate(shotgunPrefab, transform.position, transform.rotation);
+            launched = true;
+            Invoke(nameof(FireShotgun), 2f);
         }
+    }
+
+    private void FireShotgun()
+    {
+        if (shotgunPrefab == null || spawnPoint == null)
+        {
+            return;
+        }
+
+        GameObject shotgun = Instantiate(shotgunPrefab, spawnPoint.position, spawnPoint.rotation);
+        Destroy(shotgun, 2f);
     }
 }


### PR DESCRIPTION
## Summary
- Add spawn point and shotgun prefab fields to `GunnerBird`
- Trigger delayed shotgun blast after the bird is launched
- Instantiate the shotgun at the spawn point and clean it up automatically

## Testing
- `mcs Assets/Scripts/*.cs` *(fails: The type or namespace name `UnityEngine` could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_6891c870ff3c8331a38173832f889645