### PR TITLE
Add shotgun collision handler for particle system

### DIFF
--- a/Assets/Prefab/Shotgun.prefab
+++ b/Assets/Prefab/Shotgun.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 3590119225876822119}
   - component: {fileID: 7448568113774860991}
   - component: {fileID: 5095958927394289233}
+  - component: {fileID: 954440790125391718}
   m_Layer: 0
   m_Name: Shotgun
   m_TagString: Untagged
@@ -4908,3 +4909,16 @@ MonoBehaviour:
   pelletCount: 10
   spreadAngle: 10
   pelletSpeed: 40
+
+--- !u!114 &954440790125391718
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 730035116838373447}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f47f148906af4aa28e5ac14c56db72a8, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:

--- a/Assets/Scripts/ShotgunCollisionHandler.cs
+++ b/Assets/Scripts/ShotgunCollisionHandler.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ShotgunCollisionHandler : MonoBehaviour
+{
+    private float spawnTime;
+    private readonly List<ParticleCollisionEvent> _collisionEvents = new List<ParticleCollisionEvent>();
+
+    private void Awake()
+    {
+        spawnTime = Time.time;
+    }
+
+    private void OnParticleCollision(GameObject other)
+    {
+        if (Time.time - spawnTime > 0.7f)
+        {
+            return;
+        }
+
+        ParticlePhysicsExtensions.GetCollisionEvents(GetComponent<ParticleSystem>(), other, _collisionEvents);
+
+        foreach (ParticleCollisionEvent _ in _collisionEvents)
+        {
+            DestroyOnImpact target = other.GetComponent<DestroyOnImpact>();
+            if (target != null)
+            {
+                Destroy(other.gameObject);
+            }
+        }
+
+        _collisionEvents.Clear();
+    }
+}
+

--- a/Assets/Scripts/ShotgunCollisionHandler.cs.meta
+++ b/Assets/Scripts/ShotgunCollisionHandler.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: f47f148906af4aa28e5ac14c56db72a8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences:
+  - icon: {instanceID: 0}
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- implement ShotgunCollisionHandler to process particle collisions and destroy targets with DestroyOnImpact within 0.7s of spawn
- attach collision handler script to Shotgun particle system prefab

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892eed57b5c8331959df063f2795b83