### PR TITLE
Handle shotgun pellet collisions per event

### DIFF
--- a/Assets/Scripts/ShotgunCollisionHandler.cs
+++ b/Assets/Scripts/ShotgunCollisionHandler.cs
@@ -20,12 +20,12 @@ public class ShotgunCollisionHandler : MonoBehaviour
 
         ParticlePhysicsExtensions.GetCollisionEvents(GetComponent<ParticleSystem>(), other, _collisionEvents);
 
-        foreach (ParticleCollisionEvent _ in _collisionEvents)
+        foreach (ParticleCollisionEvent collisionEvent in _collisionEvents)
         {
-            DestroyOnImpact target = other.GetComponent<DestroyOnImpact>();
+            DestroyOnImpact target = collisionEvent.colliderComponent.GetComponentInParent<DestroyOnImpact>();
             if (target != null)
             {
-                Destroy(other.gameObject);
+                Destroy(target.gameObject);
             }
         }
 


### PR DESCRIPTION
## Summary
- locate destructible objects per collision event from shotgun pellets
- destroy entire destructible game object if found

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892fd82a9d48331b69952b3e6c04f43