### PR TITLE
Use parent DestroyOnImpact in shotgun pellet

### DIFF
--- a/Assets/Scripts/ShotgunPellet.cs
+++ b/Assets/Scripts/ShotgunPellet.cs
@@ -26,10 +26,10 @@ public class ShotgunPellet : MonoBehaviour
             return;
         }
 
-        DestroyOnImpact target = collision.gameObject.GetComponent<DestroyOnImpact>();
+        DestroyOnImpact target = collision.collider.GetComponentInParent<DestroyOnImpact>();
         if (target != null)
         {
-            Destroy(collision.gameObject);
+            Destroy(target.gameObject);
         }
     }
 }


### PR DESCRIPTION
## Summary
- use collision collider's parent DestroyOnImpact detection
- destroy target's root GameObject when hit

## Testing
- `mcs Assets/Scripts/ShotgunPellet.cs` *(fails: UnityEngine not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892ff3aabac83319439011e29742d68