### PR TITLE
Add GiantBird ability to grow and push nearby objects

### DIFF
--- a/Assets/Scripts/GiantBird.cs
+++ b/Assets/Scripts/GiantBird.cs
@@ -1,0 +1,59 @@
+using UnityEngine;
+using System.Collections;
+
+public class GiantBird : MonoBehaviour
+{
+    [SerializeField] private float growDelay = 2f;
+    [SerializeField] private float growDuration = 0.3f;
+    [SerializeField] private float scaleMultiplier = 5f;
+    [SerializeField] private float pushRadius = 5f;
+    [SerializeField] private float pushForce = 200f;
+
+    private Rigidbody rb;
+    private bool launched;
+
+    private void Awake()
+    {
+        rb = GetComponent<Rigidbody>();
+    }
+
+    private void Update()
+    {
+        if (!launched && rb != null && !rb.isKinematic)
+        {
+            launched = true;
+            Invoke(nameof(StartGrowAndPush), growDelay);
+        }
+    }
+
+    private void StartGrowAndPush()
+    {
+        StartCoroutine(GrowAndPush());
+    }
+
+    private IEnumerator GrowAndPush()
+    {
+        Vector3 startScale = transform.localScale;
+        Vector3 targetScale = startScale * scaleMultiplier;
+        float elapsed = 0f;
+        while (elapsed < growDuration)
+        {
+            elapsed += Time.deltaTime;
+            float t = elapsed / growDuration;
+            transform.localScale = Vector3.Lerp(startScale, targetScale, t);
+            yield return null;
+        }
+        transform.localScale = targetScale;
+
+        Collider[] colliders = Physics.OverlapSphere(transform.position, pushRadius);
+        foreach (var col in colliders)
+        {
+            Rigidbody otherRb = col.attachedRigidbody;
+            if (otherRb != null && otherRb != rb)
+            {
+                Vector3 dir = (otherRb.position - transform.position).normalized;
+                otherRb.AddForce(dir * pushForce);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/GiantBird.cs.meta
+++ b/Assets/Scripts/GiantBird.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a73e67727f3c48f4a5ca6d339c4ba7fd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add GiantBird behaviour that grows after launch and pushes nearby rigidbodies

## Testing
- `dotnet test` (fails: command not found)
- `npm test` (fails: missing package.json)


------
https://chatgpt.com/codex/tasks/task_e_68930dfe4e0c83319d8e11285f1ad6b3