### PR TITLE
Add bomb bird type and selection

### DIFF
--- a/Assets/Prefab/Bomb.prefab
+++ b/Assets/Prefab/Bomb.prefab
@@ -1,0 +1,171 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7083032839374309228
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2961661176443012880}
+  - component: {fileID: 4891878268395221034}
+  - component: {fileID: 1054065292139366159}
+  - component: {fileID: 3763032688416816071}
+  - component: {fileID: 7474350620064835790}
+  - component: {fileID: 5900551541352076850}
+  - component: {fileID: 6684783233285592}
+  m_Layer: 0
+  m_Name: Bomb
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2961661176443012880
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7083032839374309228}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &4891878268395221034
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7083032839374309228}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1054065292139366159
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7083032839374309228}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 50cd9065c9219aa4fa84bfa52bb339ab, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &3763032688416816071
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7083032839374309228}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &7474350620064835790
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7083032839374309228}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 56
+  m_CollisionDetection: 0
+--- !u!114 &5900551541352076850
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7083032839374309228}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 638a6be9123b4fdca8057f4d1e7339fe, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  type: 4
+--- !u!114 &6684783233285592
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7083032839374309228}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 29c4ec2181784beaaf8e4bf8cf098bbc, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  explosionDelay: 2
+  pushRadius: 5
+  destroyRadius: 3
+  pushForce: 500
+  explodeParticlePrefab: {fileID: 6572598219166598594, guid: b628ec9af750e7349a307cbf1c22c63b, type: 3}
+  blackMaterial: {fileID: 2100000, guid: e2b09d4a4216d434492e8bd5cca29fcf, type: 2}

--- a/Assets/Prefab/Bomb.prefab.meta
+++ b/Assets/Prefab/Bomb.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5c65fa4ee01347a0b37acf8db9a86330
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scenes/AngryBird Stage 1.unity
+++ b/Assets/Scenes/AngryBird Stage 1.unity
@@ -4749,12 +4749,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   selectedBird: 0
   birdPrefabs:
-  - {fileID: 7474350620064835790, guid: 6ff92cc47f1545b4a06d420b10938ae2, type: 3}
-  - {fileID: 7474350620064835790, guid: 471f4f1d7d514395a2ad909f56558aad, type: 3}
-  - {fileID: 7474350620064835790, guid: 400cd3e2819d4aa68838f6f271cbfe15, type: 3}
-  - {fileID: 7474350620064835790, guid: d7056d0572ea3ed4ab5829df76577d26, type: 3}
-  launchPosition: {fileID: 1154425975}
-  directionLine: {fileID: 1154425976}
+    - {fileID: 7474350620064835790, guid: 6ff92cc47f1545b4a06d420b10938ae2, type: 3}
+    - {fileID: 7474350620064835790, guid: 471f4f1d7d514395a2ad909f56558aad, type: 3}
+    - {fileID: 7474350620064835790, guid: 400cd3e2819d4aa68838f6f271cbfe15, type: 3}
+    - {fileID: 7474350620064835790, guid: d7056d0572ea3ed4ab5829df76577d26, type: 3}
+    - {fileID: 7474350620064835790, guid: 5c65fa4ee01347a0b37acf8db9a86330, type: 3}
+    launchPosition: {fileID: 1154425975}
+    directionLine: {fileID: 1154425976}
   blackHoleRadius: 5
   blackHoleForce: 50
 --- !u!4 &1154425975

--- a/Assets/Scenes/AngryBird Stage 2.unity
+++ b/Assets/Scenes/AngryBird Stage 2.unity
@@ -2449,6 +2449,7 @@ MonoBehaviour:
   - {fileID: 7474350620064835790, guid: 1aa4ca905d0800d4f91ecf0df524cd42, type: 3}
   - {fileID: 7474350620064835790, guid: 471f4f1d7d514395a2ad909f56558aad, type: 3}
   - {fileID: 7474350620064835790, guid: 400cd3e2819d4aa68838f6f271cbfe15, type: 3}
+  - {fileID: 7474350620064835790, guid: 5c65fa4ee01347a0b37acf8db9a86330, type: 3}
   launchPosition: {fileID: 1154425975}
   directionLine: {fileID: 1154425976}
   blackHoleRadius: 5

--- a/Assets/Scenes/AngryBird Stage 3.unity
+++ b/Assets/Scenes/AngryBird Stage 3.unity
@@ -3049,6 +3049,7 @@ MonoBehaviour:
   - {fileID: 7474350620064835790, guid: 1aa4ca905d0800d4f91ecf0df524cd42, type: 3}
   - {fileID: 7474350620064835790, guid: 471f4f1d7d514395a2ad909f56558aad, type: 3}
   - {fileID: 7474350620064835790, guid: 400cd3e2819d4aa68838f6f271cbfe15, type: 3}
+  - {fileID: 7474350620064835790, guid: 5c65fa4ee01347a0b37acf8db9a86330, type: 3}
   launchPosition: {fileID: 1154425975}
   directionLine: {fileID: 1154425976}
   blackHoleRadius: 5

--- a/Assets/Scripts/BirdLauncher.cs
+++ b/Assets/Scripts/BirdLauncher.cs
@@ -104,6 +104,10 @@ public class BirdLauncher : MonoBehaviour
         {
             ChooseGiantBird();
         }
+        else if (Input.GetKeyDown(KeyCode.Alpha5))
+        {
+            ChooseBombBird();
+        }
     }
 
     void HandleInput()
@@ -198,6 +202,7 @@ public class BirdLauncher : MonoBehaviour
     public void ChooseBlackHoleBird() => ChooseBird(BirdType.Type.BlackHole);
     public void ChooseGunnerBird() => ChooseBird(BirdType.Type.Gunner);
     public void ChooseGiantBird() => ChooseBird(BirdType.Type.Giant);
+    public void ChooseBombBird() => ChooseBird(BirdType.Type.Bomb);
 
     public void ChooseBird(BirdType.Type type)
     {

--- a/Assets/Scripts/BirdType.cs
+++ b/Assets/Scripts/BirdType.cs
@@ -2,6 +2,6 @@ using UnityEngine;
 
 public class BirdType : MonoBehaviour
 {
-    public enum Type { Basic, BlackHole, Gunner, Giant }
+    public enum Type { Basic, BlackHole, Gunner, Giant, Bomb }
     public Type type;
 }


### PR DESCRIPTION
## Summary
- expand `BirdType.Type` enum to include new Bomb bird
- enable selecting a Bomb bird via `Alpha5` and add `ChooseBombBird`
- create Bomb bird prefab and reference it in scenes

## Testing
- `dotnet test` *(fails: command not found)*
- `python -m pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68943c31664c83319cee90ee4d03b3d6