### PR TITLE
Add camera director to manage intro pan

### DIFF
--- a/Assets/Scripts/CameraDirector.cs
+++ b/Assets/Scripts/CameraDirector.cs
@@ -1,0 +1,72 @@
+using UnityEngine;
+using System.Collections;
+
+public class CameraDirector : MonoBehaviour
+{
+    public Transform MainCamPos;
+    public Transform FirstCamPos;
+    public float slowSpeed = 2f;
+    public float fastSpeed = 5f;
+    public float waitTime = 1f;
+
+    private BirdLauncher launcher;
+
+    void Start()
+    {
+        launcher = FindObjectOfType<BirdLauncher>();
+        if (launcher != null)
+        {
+            launcher.enabled = false;
+        }
+
+        StartCoroutine(CameraSequence());
+    }
+
+    private IEnumerator CameraSequence()
+    {
+        if (MainCamPos != null)
+        {
+            transform.position = MainCamPos.position;
+            transform.rotation = MainCamPos.rotation;
+        }
+
+        if (MainCamPos != null && FirstCamPos != null)
+        {
+            while (Vector3.Distance(transform.position, FirstCamPos.position) > 0.01f ||
+                   Quaternion.Angle(transform.rotation, FirstCamPos.rotation) > 0.1f)
+            {
+                transform.position = Vector3.MoveTowards(
+                    transform.position,
+                    FirstCamPos.position,
+                    slowSpeed * Time.deltaTime);
+                transform.rotation = Quaternion.RotateTowards(
+                    transform.rotation,
+                    FirstCamPos.rotation,
+                    slowSpeed * 100f * Time.deltaTime);
+                yield return null;
+            }
+
+            yield return new WaitForSeconds(waitTime);
+
+            while (Vector3.Distance(transform.position, MainCamPos.position) > 0.01f ||
+                   Quaternion.Angle(transform.rotation, MainCamPos.rotation) > 0.1f)
+            {
+                transform.position = Vector3.MoveTowards(
+                    transform.position,
+                    MainCamPos.position,
+                    fastSpeed * Time.deltaTime);
+                transform.rotation = Quaternion.RotateTowards(
+                    transform.rotation,
+                    MainCamPos.rotation,
+                    fastSpeed * 100f * Time.deltaTime);
+                yield return null;
+            }
+        }
+
+        if (launcher != null)
+        {
+            launcher.enabled = true;
+        }
+    }
+}
+

--- a/Assets/Scripts/CameraDirector.cs.meta
+++ b/Assets/Scripts/CameraDirector.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 10d776631e1241938adeab3ede7adae6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences:
+  - icon: {instanceID: 0}
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- disable BirdLauncher during intro camera pan
- slide camera to intro viewpoint then back to main view
- re-enable BirdLauncher after pan

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68946324cd2c8331a035a866ae1fc054