### PR TITLE
feat: add camera follow for launched birds

### DIFF
--- a/Assets/Scripts/BirdLauncher.cs
+++ b/Assets/Scripts/BirdLauncher.cs
@@ -12,6 +12,9 @@ public class BirdLauncher : MonoBehaviour
     public Transform launchPosition;
     public LineRenderer directionLine; // shows predicted direction
 
+    [SerializeField]
+    private CameraDirector cameraDirector;
+
     [Header("Black Hole Settings")]
     public float blackHoleRadius = 5f;
     public float blackHoleForce = 50f;
@@ -36,6 +39,10 @@ public class BirdLauncher : MonoBehaviour
 
     void SpawnBird()
     {
+        if (cameraDirector != null)
+        {
+            cameraDirector.ReturnToMain();
+        }
         CancelInvoke(nameof(SpawnBird));
         if (currentBird != null && currentBird.isKinematic)
         {
@@ -155,6 +162,10 @@ public class BirdLauncher : MonoBehaviour
 
             currentBird.isKinematic = false;
             currentBird.AddForce(force * 500f);
+            if (cameraDirector != null)
+            {
+                cameraDirector.FollowBird(currentBird.transform);
+            }
 
             if (selectedBird == BirdType.Type.BlackHole)
             {

--- a/Assets/Scripts/CameraDirector.cs
+++ b/Assets/Scripts/CameraDirector.cs
@@ -10,6 +10,8 @@ public class CameraDirector : MonoBehaviour
     public float waitTime = 1f;
 
     private BirdLauncher launcher;
+    private Transform targetBird;
+    private bool returning;
 
     void Start()
     {
@@ -20,6 +22,25 @@ public class CameraDirector : MonoBehaviour
         }
 
         StartCoroutine(CameraSequence());
+    }
+
+    void LateUpdate()
+    {
+        if (targetBird != null)
+        {
+            Vector3 pos = transform.position;
+            pos.x = targetBird.position.x;
+            transform.position = pos;
+        }
+        else if (returning && MainCamPos != null)
+        {
+            transform.position = Vector3.Lerp(transform.position, MainCamPos.position, fastSpeed * Time.deltaTime);
+            if (Vector3.Distance(transform.position, MainCamPos.position) < 0.1f)
+            {
+                transform.position = MainCamPos.position;
+                returning = false;
+            }
+        }
     }
 
     private IEnumerator CameraSequence()
@@ -67,6 +88,18 @@ public class CameraDirector : MonoBehaviour
         {
             launcher.enabled = true;
         }
+    }
+
+    public void FollowBird(Transform bird)
+    {
+        targetBird = bird;
+        returning = false;
+    }
+
+    public void ReturnToMain()
+    {
+        targetBird = null;
+        returning = true;
     }
 }
 


### PR DESCRIPTION
## Summary
- add CameraDirector reference to BirdLauncher to manage camera transitions
- follow launched bird and reset camera when spawning new bird
- implement CameraDirector methods to follow bird and return to main position

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6894649558048331a1d50f58c4e4a56f