### PR TITLE
Manage BirdLauncher state during camera sequences

### DIFF
--- a/Assets/Scripts/BirdLauncher.cs
+++ b/Assets/Scripts/BirdLauncher.cs
@@ -28,7 +28,6 @@ public class BirdLauncher : MonoBehaviour
     void Start()
     {
         cam = Camera.main;
-        SpawnBird();
 
         if (directionLine != null)
         {
@@ -37,12 +36,24 @@ public class BirdLauncher : MonoBehaviour
         }
     }
 
-    void SpawnBird()
+    void OnEnable()
     {
         if (cameraDirector != null)
         {
-            cameraDirector.ReturnToMain();
+            cameraDirector.OnSequenceComplete += SpawnBird;
         }
+    }
+
+    void OnDisable()
+    {
+        if (cameraDirector != null)
+        {
+            cameraDirector.OnSequenceComplete -= SpawnBird;
+        }
+    }
+
+    void SpawnBird()
+    {
         CancelInvoke(nameof(SpawnBird));
         if (currentBird != null && currentBird.isKinematic)
         {
@@ -164,7 +175,7 @@ public class BirdLauncher : MonoBehaviour
             currentBird.AddForce(force * 500f);
             if (cameraDirector != null)
             {
-                cameraDirector.FollowBird(currentBird.transform);
+                cameraDirector.FollowBird(currentBird.transform, 4f);
             }
 
             if (selectedBird == BirdType.Type.BlackHole)
@@ -172,7 +183,6 @@ public class BirdLauncher : MonoBehaviour
                 Invoke(nameof(ActivateBlackHole), 2.5f);
             }
 
-            Invoke(nameof(SpawnBird), 4f);
             isDragging = false;
         }
     }

--- a/Assets/Scripts/CameraDirector.cs
+++ b/Assets/Scripts/CameraDirector.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using System.Collections;
+using System;
 
 public class CameraDirector : MonoBehaviour
 {
@@ -12,6 +13,9 @@ public class CameraDirector : MonoBehaviour
     private BirdLauncher launcher;
     private Transform targetBird;
     private bool returning;
+    private bool isSequenceRunning;
+
+    public event Action OnSequenceComplete;
 
     void Start()
     {
@@ -21,6 +25,7 @@ public class CameraDirector : MonoBehaviour
             launcher.enabled = false;
         }
 
+        isSequenceRunning = true;
         StartCoroutine(CameraSequence());
     }
 
@@ -39,6 +44,12 @@ public class CameraDirector : MonoBehaviour
             {
                 transform.position = MainCamPos.position;
                 returning = false;
+                isSequenceRunning = false;
+                if (launcher != null)
+                {
+                    launcher.enabled = true;
+                }
+                OnSequenceComplete?.Invoke();
             }
         }
     }
@@ -84,22 +95,46 @@ public class CameraDirector : MonoBehaviour
             }
         }
 
+        isSequenceRunning = false;
         if (launcher != null)
         {
             launcher.enabled = true;
         }
+        OnSequenceComplete?.Invoke();
     }
 
-    public void FollowBird(Transform bird)
+    public void FollowBird(Transform bird, float returnDelay = 0f)
     {
         targetBird = bird;
         returning = false;
+        isSequenceRunning = true;
+        if (launcher != null)
+        {
+            launcher.enabled = false;
+        }
+        if (returnDelay > 0f)
+        {
+            StartCoroutine(ReturnAfterDelay(returnDelay));
+        }
     }
 
     public void ReturnToMain()
     {
         targetBird = null;
         returning = true;
+        isSequenceRunning = true;
+        if (launcher != null)
+        {
+            launcher.enabled = false;
+        }
     }
+
+    private IEnumerator ReturnAfterDelay(float delay)
+    {
+        yield return new WaitForSeconds(delay);
+        ReturnToMain();
+    }
+
+    public bool IsSequenceRunning => isSequenceRunning;
 }
 


### PR DESCRIPTION
## Summary
- Track camera movement via `isSequenceRunning` and notify listeners when motion completes
- Disable `BirdLauncher` while camera moves and re-enable once the camera returns to main position
- Spawn birds when camera is ready using a callback-driven link between `CameraDirector` and `BirdLauncher`

## Testing
- `mcs Assets/Scripts/*.cs -out:/tmp/test.exe` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689466198250833185caf99b488cf5b1