### PR TITLE
Ensure camera director is assigned

### DIFF
--- a/Assets/Scripts/BirdLauncher.cs
+++ b/Assets/Scripts/BirdLauncher.cs
@@ -25,6 +25,18 @@ public class BirdLauncher : MonoBehaviour
     private bool blackHoleActive;
     private bool isDragging;
 
+    void Awake()
+    {
+        if (cameraDirector == null)
+        {
+            cameraDirector = FindObjectOfType<CameraDirector>();
+            if (cameraDirector == null)
+            {
+                Debug.LogWarning("CameraDirector not found. BirdLauncher may not function correctly.");
+            }
+        }
+    }
+
     void Start()
     {
         cam = Camera.main;


### PR DESCRIPTION
## Summary
- Add `Awake` method to `BirdLauncher` that locates a `CameraDirector` if none is set and logs a warning when missing

## Testing
- `dotnet test` *(fails: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68946d5153a08331b2f37f3d34ae17fc