### PR TITLE
Add stage bird configuration and restrict launcher

### DIFF
--- a/Assets/Scripts/BirdLauncher.cs
+++ b/Assets/Scripts/BirdLauncher.cs
@@ -19,6 +19,8 @@ public class BirdLauncher : MonoBehaviour
     [SerializeField]
     private CameraDirector cameraDirector;
 
+    private readonly HashSet<BirdType.Type> availableTypes = new HashSet<BirdType.Type>();
+
     private Rigidbody currentBird;
     private Vector3 dragStart;
     private Camera cam;
@@ -45,6 +47,8 @@ public class BirdLauncher : MonoBehaviour
             directionLine.positionCount = 0;
             directionLine.enabled = false;
         }
+
+        LoadStageConfig();
     }
 
     void OnEnable()
@@ -71,12 +75,36 @@ public class BirdLauncher : MonoBehaviour
 
     void HandleBirdSelectionInput()
     {
-        if (Input.GetKeyDown(KeyCode.Alpha1)) ChooseBasicBird();
-        else if (Input.GetKeyDown(KeyCode.Alpha2)) ChooseBlackHoleBird();
-        else if (Input.GetKeyDown(KeyCode.Alpha3)) ChooseGunnerBird();
-        else if (Input.GetKeyDown(KeyCode.Alpha4)) ChooseGiantBird();
-        else if (Input.GetKeyDown(KeyCode.Alpha5)) ChooseBombBird();
-        else if (Input.GetKeyDown(KeyCode.Alpha6)) ChooseLaserBird();
+        if (Input.GetKeyDown(KeyCode.Alpha1))
+        {
+            if (IsTypeAvailable(BirdType.Type.Basic)) ChooseBasicBird();
+            else ShowUnavailable(BirdType.Type.Basic);
+        }
+        else if (Input.GetKeyDown(KeyCode.Alpha2))
+        {
+            if (IsTypeAvailable(BirdType.Type.BlackHole)) ChooseBlackHoleBird();
+            else ShowUnavailable(BirdType.Type.BlackHole);
+        }
+        else if (Input.GetKeyDown(KeyCode.Alpha3))
+        {
+            if (IsTypeAvailable(BirdType.Type.Gunner)) ChooseGunnerBird();
+            else ShowUnavailable(BirdType.Type.Gunner);
+        }
+        else if (Input.GetKeyDown(KeyCode.Alpha4))
+        {
+            if (IsTypeAvailable(BirdType.Type.Giant)) ChooseGiantBird();
+            else ShowUnavailable(BirdType.Type.Giant);
+        }
+        else if (Input.GetKeyDown(KeyCode.Alpha5))
+        {
+            if (IsTypeAvailable(BirdType.Type.Bomb)) ChooseBombBird();
+            else ShowUnavailable(BirdType.Type.Bomb);
+        }
+        else if (Input.GetKeyDown(KeyCode.Alpha6))
+        {
+            if (IsTypeAvailable(BirdType.Type.Laser)) ChooseLaserBird();
+            else ShowUnavailable(BirdType.Type.Laser);
+        }
     }
 
     void HandleInput()
@@ -178,7 +206,7 @@ public class BirdLauncher : MonoBehaviour
         return Vector3.zero;
     }
 
-    // Bird 타입 변경 함수들
+    // Bird selection wrapper methods
     public void ChooseBasicBird() => ChooseBird(BirdType.Type.Basic);
     public void ChooseBlackHoleBird() => ChooseBird(BirdType.Type.BlackHole);
     public void ChooseGunnerBird() => ChooseBird(BirdType.Type.Gunner);
@@ -191,4 +219,47 @@ public class BirdLauncher : MonoBehaviour
         selectedBird = type;
         SpawnBird();
     }
+
+    void LoadStageConfig()
+    {
+        StageBirdConfig config = FindObjectOfType<StageBirdConfig>();
+
+        availableTypes.Clear();
+
+        if (config != null && config.allowedBirdTypes != null && config.allowedBirdTypes.Count > 0)
+        {
+            foreach (var t in config.allowedBirdTypes)
+            {
+                availableTypes.Add(t);
+            }
+
+            birdPrefabs = birdPrefabs.FindAll(rb =>
+            {
+                BirdType bt = rb.GetComponent<BirdType>();
+                return bt != null && availableTypes.Contains(bt.type);
+            });
+
+            if (!availableTypes.Contains(selectedBird) && birdPrefabs.Count > 0)
+            {
+                BirdType bt = birdPrefabs[0].GetComponent<BirdType>();
+                if (bt != null) selectedBird = bt.type;
+            }
+        }
+        else
+        {
+            foreach (var rb in birdPrefabs)
+            {
+                BirdType bt = rb.GetComponent<BirdType>();
+                if (bt != null) availableTypes.Add(bt.type);
+            }
+        }
+    }
+
+    bool IsTypeAvailable(BirdType.Type type) => availableTypes.Contains(type);
+
+    void ShowUnavailable(BirdType.Type type)
+    {
+        Debug.Log($"{type} bird is not available in this stage.");
+    }
 }
+

--- a/Assets/Scripts/StageBirdConfig.cs
+++ b/Assets/Scripts/StageBirdConfig.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Configuration component describing which bird types are available in a scene.
+/// Attach this to a GameObject in the scene and populate the list in the editor
+/// to restrict the birds that the <see cref="BirdLauncher"/> can spawn.
+/// </summary>
+public class StageBirdConfig : MonoBehaviour
+{
+    /// <summary>
+    /// List of bird types that are allowed for this stage. When empty, all
+    /// birds are considered available.
+    /// </summary>
+    public List<BirdType.Type> allowedBirdTypes = new List<BirdType.Type>();
+}
+

--- a/Assets/Scripts/StageBirdConfig.cs.meta
+++ b/Assets/Scripts/StageBirdConfig.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 0a1c82102d0f42be9b6889197181ec44
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+


### PR DESCRIPTION
## Summary
- add StageBirdConfig component for restricting available bird types per scene
- update BirdLauncher to load configuration, filter prefabs, and ignore unavailable selections

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*
- `mcs -out:/tmp/build.exe Assets/Scripts/*.cs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68958f98eb788331a0e81235b90b6b8f